### PR TITLE
Migration from aioxmpp to slixmpp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-spade>=3.2.2
-spade_pubsub>=0.1.3
-loguru==0.5.3
+spade>=4.1.0
+spade_pubsub>=0.2.1
 pandas~=2.0.3
-aiohttp>=3.8.4
 pymysql==1.1.0
 psycopg2-binary~=2.9.9
 pymongo~=4.6.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,19 +3,17 @@ bumpversion==0.6.0
 wheel==0.36.2
 watchdog==2.0.2
 flake8==3.9.1
-black==20.8b1
+black==22.3.0
 tox==3.23.0
 coverage==5.5
 Sphinx==3.5.4
 twine==1.11.0
 
-pytest==5.4
-pytest-runner==4.2
-asynctest==0.13.0
+pytest==8.4.0
 pytest-asyncio==0.14.0
 pytest-cov==2.11.1
 pytest-mock==3.5.1
-pluggy==0.13.1
+pluggy>=1.5.0
 python-coveralls==2.9.3
 requests==2.25.1
 parsel==1.6.0

--- a/spade_artifact/agent.py
+++ b/spade_artifact/agent.py
@@ -2,13 +2,8 @@ from loguru import logger
 from spade_pubsub import PubSubMixin
 from slixmpp.stanza.message import Message as SlixmppMessage
 
-class ArtifactMixin(PubSubMixin):
-    def __init__(self, *args, pubsub_server=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.pubsub_server = (
-            pubsub_server if pubsub_server else f"pubsub.{self.jid.domain}"
-        )
 
+class ArtifactMixin(PubSubMixin):
     async def _hook_plugin_after_connection(self, *args, **kwargs):
         try:
             await super()._hook_plugin_after_connection(*args, **kwargs)
@@ -17,6 +12,12 @@ class ArtifactMixin(PubSubMixin):
 
         self.artifacts = ArtifactComponent(self)
         self.pubsub.set_on_item_published(self.artifacts.on_item_published)
+
+    def __init__(self, *args, pubsub_server=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pubsub_server = (
+            pubsub_server if pubsub_server else f"pubsub.{self.jid.domain}"
+        )
 
 
 class ArtifactComponent:
@@ -29,7 +30,7 @@ class ArtifactComponent:
         if node in self.focus_callbacks:
             item = msg['pubsub_event']['items']['item']['payload']
             jid = msg['pubsub_event']['items']['item']['publisher']
-            self.focus_callbacks[node](jid, item)
+            self.focus_callbacks[node](jid, item.text)
 
     async def focus(self, artifact_jid, callback):
         await self.agent.pubsub.subscribe(self.agent.pubsub_server, str(artifact_jid))

--- a/spade_artifact/agent.py
+++ b/spade_artifact/agent.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from spade_pubsub import PubSubMixin
-
+from slixmpp.stanza.message import Message as SlixmppMessage
 
 class ArtifactMixin(PubSubMixin):
     def __init__(self, *args, pubsub_server=None, **kwargs):
@@ -24,9 +24,12 @@ class ArtifactComponent:
         self.agent = agent
         self.focus_callbacks = {}
 
-    def on_item_published(self, jid, node, item, message=None):
+    def on_item_published(self, msg: SlixmppMessage):
+        node = msg['pubsub_event']['items']['node']
         if node in self.focus_callbacks:
-            self.focus_callbacks[node](node, item.registered_payload.data)
+            item = msg['pubsub_event']['items']['item']['payload']
+            jid = msg['pubsub_event']['items']['item']['publisher']
+            self.focus_callbacks[node](jid, item)
 
     async def focus(self, artifact_jid, callback):
         await self.agent.pubsub.subscribe(self.agent.pubsub_server, str(artifact_jid))

--- a/spade_artifact/agent.py
+++ b/spade_artifact/agent.py
@@ -4,6 +4,12 @@ from slixmpp.stanza.message import Message as SlixmppMessage
 
 
 class ArtifactMixin(PubSubMixin):
+    def __init__(self, *args, pubsub_server=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pubsub_server = (
+            pubsub_server if pubsub_server else f"pubsub.{self.jid.domain}"
+        )
+
     async def _hook_plugin_after_connection(self, *args, **kwargs):
         try:
             await super()._hook_plugin_after_connection(*args, **kwargs)
@@ -12,12 +18,6 @@ class ArtifactMixin(PubSubMixin):
 
         self.artifacts = ArtifactComponent(self)
         self.pubsub.set_on_item_published(self.artifacts.on_item_published)
-
-    def __init__(self, *args, pubsub_server=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.pubsub_server = (
-            pubsub_server if pubsub_server else f"pubsub.{self.jid.domain}"
-        )
 
 
 class ArtifactComponent:

--- a/spade_artifact/artifact.py
+++ b/spade_artifact/artifact.py
@@ -33,7 +33,7 @@ class AbstractArtifact(object, metaclass=abc.ABCMeta):
 
 
 class Artifact(PubSubMixin, AbstractArtifact):
-    def __init__(self, jid, password, pubsub_server=None, verify_security=False):
+    def __init__(self, jid, password, pubsub_server=None, port=5222, verify_security=False):
         """
         Creates an artifact
 
@@ -43,6 +43,7 @@ class Artifact(PubSubMixin, AbstractArtifact):
           verify_security (bool): Wether to verify or not the SSL certificates
         """
         self.jid = JID(jid)
+        self.xmpp_port = port
         self.password = password
         self.verify_security = verify_security
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,16 @@
 import pytest
-from aioxmpp import JID
+from slixmpp.jid import JID
 
 from tests.factories import MockedConnectedArtifactAgentFactory
 
 
 @pytest.fixture
 def jid():
-    return JID.fromstr("friend@localhost/home")
+    return JID("friend@localhost/home")
 
 
 @pytest.fixture
-def agent():
+async def agent():
     agent = MockedConnectedArtifactAgentFactory()
-    future = agent.start()
-    future.result()
-    return agent
+    await agent.start()
+    yield agent

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,8 +1,10 @@
-import factory
-from aioxmpp import PresenceShow, PresenceState
-from asynctest import CoroutineMock, Mock
-from spade.agent import Agent
+import asyncio
 
+import factory
+from unittest.mock import AsyncMock, Mock
+from spade.presence import PresenceShow
+
+from spade.agent import Agent
 from spade_artifact import Artifact, ArtifactMixin
 
 
@@ -13,10 +15,8 @@ class MockedConnectedArtifact(Artifact):
         super().__init__(*args, **kwargs)
         if status is None:
             status = {}
-        self._async_connect = CoroutineMock()
-        self._async_register = CoroutineMock()
-        self.conn_coro = Mock()
-        self.conn_coro.__aexit__ = CoroutineMock()
+        self._async_connect = AsyncMock()
+        self._async_register = AsyncMock()
 
         self.available = available
         self.show = show
@@ -26,13 +26,13 @@ class MockedConnectedArtifact(Artifact):
     async def _hook_plugin_after_connection(self, *args, **kwargs):
         await super()._hook_plugin_after_connection(*args, **kwargs)
         self.pubsub = Mock()
-        self.pubsub.create = CoroutineMock()
+        self.pubsub.create = AsyncMock()
 
     def mock_presence(self):
         show = self.show if self.show is not None else PresenceShow.NONE
-        available = self.available if self.available is not None else False
-        state = PresenceState(available, show)
-        self.presence.presenceserver.set_presence(state, self.status, self.priority)
+        status = self.status if self.status is not None else ""
+        priority = self.priority if self.priority is not None else 0
+        self.presence.set_presence(show=show, status=status, priority=priority)
 
     async def run(self):
         self.set("test_passed", True)
@@ -54,17 +54,14 @@ class MockedConnectedArtifactFactory(factory.Factory):
 class MockedConnectedArtifactAgent(ArtifactMixin, Agent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._async_connect = CoroutineMock()
-        self._async_register = CoroutineMock()
-        self.conn_coro = Mock()
-        self.conn_coro.__aexit__ = CoroutineMock()
-        self.stream = Mock()
+        self._async_connect = AsyncMock()
+        self._async_register = AsyncMock()
 
     async def _hook_plugin_after_connection(self, *args, **kwargs):
         await super()._hook_plugin_after_connection(*args, **kwargs)
         self.pubsub = Mock()
-        self.pubsub.subscribe = CoroutineMock()
-        self.pubsub.unsubscribe = CoroutineMock()
+        self.pubsub.subscribe = AsyncMock()
+        self.pubsub.unsubscribe = AsyncMock()
 
 
 class MockedConnectedArtifactAgentFactory(factory.Factory):

--- a/tests/test_agent_mixin.py
+++ b/tests/test_agent_mixin.py
@@ -1,6 +1,8 @@
 import collections
+from unittest.mock import Mock
+from xml.etree.ElementTree import Element
 
-from asynctest import Mock
+from slixmpp.stanza.message import Message as SlixmppMessage
 from spade.behaviour import OneShotBehaviour
 
 from spade_artifact.agent import ArtifactComponent
@@ -22,7 +24,7 @@ def test_artifacts_component(agent):
     assert agent.artifacts.focus_callbacks == {}
 
 
-def test_focus(agent):
+async def test_focus(agent):
     callback = Mock()
 
     class FocusBehaviour(OneShotBehaviour):
@@ -32,14 +34,14 @@ def test_focus(agent):
 
     behav = FocusBehaviour()
     agent.add_behaviour(behav)
-    behav.join()
-    agent.stop()
+    await behav.join()
+    await agent.stop()
     agent.pubsub.subscribe.assert_called_with(agent.pubsub_server, "artifact@server")
 
     assert agent.artifacts.focus_callbacks["artifact@server"] == callback
 
 
-def test_ignore(agent):
+async def test_ignore(agent):
     callback = Mock()
 
     class FocusBehaviour(OneShotBehaviour):
@@ -49,14 +51,14 @@ def test_ignore(agent):
 
     behav = FocusBehaviour()
     agent.add_behaviour(behav)
-    behav.join()
-    agent.stop()
+    await behav.join()
+    await agent.stop()
     agent.pubsub.unsubscribe.assert_called_with(agent.pubsub_server, "artifact@server")
 
     assert "artifact@server" not in agent.artifacts.focus_callbacks
 
 
-def test_set_on_item_published(agent):
+async def test_set_on_item_published(agent):
     callback = Mock()
 
     class FocusBehaviour(OneShotBehaviour):
@@ -65,7 +67,7 @@ def test_set_on_item_published(agent):
 
     behav = FocusBehaviour()
     agent.add_behaviour(behav)
-    behav.join()
+    await behav.join()
 
     class Item:
         def __init__(self, data):
@@ -73,12 +75,13 @@ def test_set_on_item_published(agent):
             _data = collections.namedtuple("data", "data")
             self.registered_payload = _data(data=self.data)
 
-    agent.artifacts.on_item_published(
-        jid="artifact@server",
-        node="artifact@server",
-        item=Item("payload"),
-        message=None,
-    )
+    msg = SlixmppMessage()
+    msg['pubsub_event']['items']['node'] = "artifact@server"
+    msg['pubsub_event']['items']['item']['publisher'] = "artifact@server"
+    msg['pubsub_event']['items']['item']['payload'] = Element("{}",)
+    msg['pubsub_event']['items']['item']['payload'].text = "payload"
+
+    agent.artifacts.on_item_published(msg)
 
     assert callback.called_with("artifact@server", "payload")
-    agent.stop()
+    await agent.stop()

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -2,21 +2,27 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `spade_artifact` package."""
-from asynctest import Mock, CoroutineMock
+import asyncio
+from unittest.mock import Mock, AsyncMock, MagicMock
+
+import pytest
 from spade.message import Message
+from slixmpp import Message as SlixmppMessage
 
 from tests.factories import MockedConnectedArtifactFactory, MockedConnectedArtifact
 
 
-def test_run():
+async def test_run():
     artifact = MockedConnectedArtifactFactory()
-    future = artifact.start()
-    future.result()
-    artifact.join()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start()
+
+    await artifact.join()
+
     assert artifact.get("test_passed")
 
 
-def test_setup():
+async def test_setup():
     class TestArtifact(MockedConnectedArtifact):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -29,28 +35,30 @@ def test_setup():
             self.kill()
 
     artifact = TestArtifact(jid="fake@jid", password="fake_password")
+    artifact.loop = asyncio.get_event_loop()
 
     assert artifact.value is False
-    future = artifact.start()
-    future.result()
-    artifact.join()
+    await artifact.start()
+    await artifact.join()
     assert artifact.value
 
 
-def test_name():
+async def test_name():
     artifact = MockedConnectedArtifactFactory()
     assert artifact.name == "fake"
 
 
-def test_is_alive():
+async def test_is_alive():
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+
     assert artifact.is_alive() is False
-    future = artifact.start()
-    future.result()
+    await artifact.start()
+
     assert artifact.is_alive()
 
 
-def test_set_get():
+async def test_set_get():
     artifact = MockedConnectedArtifactFactory()
 
     assert artifact.get("A_KEY") is None
@@ -64,61 +72,66 @@ def test_set_get():
     assert artifact.get("A_KEY") == 1234
 
 
-def test_send_msg():
+@pytest.mark.asyncio
+async def test_send_msg():
+    message = MagicMock()
+    message_prepare = MagicMock()
+    message.prepare.return_value = message_prepare
+
     class A(MockedConnectedArtifact):
         async def run(self):
-            self.client = Mock()
-            self.client.send = CoroutineMock()
-            msg = Message()
-            await self.send(msg)
+            self.client = MagicMock()
+            self.client.send = AsyncMock()
+            await self.send(message)
             self.kill()
 
     artifact = A(jid="fakejid", password="fakesecret")
+    artifact.loop = asyncio.get_event_loop()
 
-    future = artifact.start()
-    future.result()
-    artifact.join()
+    await artifact.start()
+    await artifact.join()
 
-    assert artifact.client.send.called_with(Message().prepare())
+    artifact.client.send.assert_called_with(message_prepare)
+    message.prepare.assert_called_with(artifact.client)
 
 
-def test_receive():
+@pytest.mark.asyncio
+async def test_receive():
     class A(MockedConnectedArtifact):
         async def run(self):
             self.client = Mock()
-            self.client.send = CoroutineMock()
+            self.client.send = AsyncMock()
             self.msg = await self.receive(1)
             self.kill()
 
     artifact = A(jid="fakejid", password="fakesecret")
+    artifact.loop = asyncio.get_event_loop()
+    artifact._message_received(SlixmppMessage())
 
-    artifact._message_received(Message().prepare())
-
-    future = artifact.start()
-    future.result()
-    artifact.join()
+    await artifact.start()
+    await artifact.join()
 
     assert artifact.msg == Message()
 
 
-def test_mailbox_size():
+@pytest.mark.asyncio
+async def test_mailbox_size():
     class A(MockedConnectedArtifact):
         async def run(self):
             self.client = Mock()
-            self.client.send = CoroutineMock()
+            self.client.send = AsyncMock()
             self.msg = await self.receive(1)
             self.kill()
 
     artifact = A(jid="fakejid", password="fakesecret")
+    artifact.loop = asyncio.get_event_loop()
 
-    future = artifact._message_received(Message().prepare())
-    future.result()
+    artifact._message_received(SlixmppMessage())
 
     assert artifact.mailbox_size() == 1
 
-    future = artifact.start()
-    future.result()
-    artifact.join()
+    await artifact.start()
+    await artifact.join()
 
     assert artifact.msg == Message()
 

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -2,559 +2,579 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `spade_artifact` presence."""
-
-from unittest.mock import Mock
+import asyncio
+from unittest.mock import Mock, MagicMock
 
 import pytest
-from aioxmpp import PresenceShow, PresenceState, PresenceType, Presence, JID
-from aioxmpp.roster.xso import Item as XSOItem
-from spade.presence import ContactNotFound
+import spade.presence
+from slixmpp import JID
+from slixmpp.stanza import Iq
+from slixmpp.stanza.roster import Roster
+from spade.presence import PresenceShow, PresenceType, Presence
+from spade.presence import ContactNotFound, Contact
 
 from tests.factories import MockedConnectedArtifactFactory
 
 
-def test_set_available():
+async def test_set_available():
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
     artifact.presence.set_available()
     assert artifact.presence.is_available()
 
 
-def test_set_available_with_show():
+async def test_set_available_with_show():
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    artifact.presence.set_available(show=PresenceShow.CHAT)
+    artifact.presence.set_available()
     assert artifact.presence.is_available()
-    assert artifact.presence.state.show == PresenceShow.CHAT
+    assert artifact.presence.current_presence.show == PresenceShow.CHAT
 
 
-def test_set_unavailable():
+async def test_set_unavailable():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.set_unavailable()
 
     assert not artifact.presence.is_available()
 
 
-def test_get_state_show():
+async def test_get_state_show():
     artifact = MockedConnectedArtifactFactory(available=True, show=PresenceShow.AWAY)
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.state.show == PresenceShow.AWAY
+    assert artifact.presence.current_presence.show == PresenceShow.AWAY
 
 
-def test_get_status_empty():
-    artifact = MockedConnectedArtifactFactory(status={})
+async def test_get_status_empty():
+    artifact = MockedConnectedArtifactFactory(status="")
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.status == {}
+    assert artifact.presence.current_presence.status == ""
 
 
-def test_get_status_string():
+async def test_get_status_string():
     artifact = MockedConnectedArtifactFactory(status="Working")
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.status == {None: "Working"}
+    assert artifact.presence.current_presence.status == "Working"
 
 
-def test_get_status_dict():
-    artifact = MockedConnectedArtifactFactory(status={"en": "Working"})
+async def test_get_status_dict():
+    artifact = MockedConnectedArtifactFactory(status="Working")
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.status == {"en": "Working"}
+    assert artifact.presence.current_presence.status == "Working"
 
 
-def test_get_priority_default():
+async def test_get_priority_default():
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.priority == 0
+    assert artifact.presence.current_presence.priority == 0
 
 
-def test_get_priority():
+async def test_get_priority():
     artifact = MockedConnectedArtifactFactory(priority=10)
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
     artifact.mock_presence()
 
-    assert artifact.presence.priority == 10
+    assert artifact.presence.current_presence.priority == 10
 
 
-def test_set_presence_available():
+async def test_set_presence_status():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
-
-    artifact.presence.set_presence(state=PresenceState(available=True))
-
-    assert artifact.presence.is_available()
-
-
-def test_set_presence_unavailable():
-    artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
-
-    artifact.presence.set_presence(state=PresenceState(available=False))
-
-    assert not artifact.presence.is_available()
-
-
-def test_set_presence_status():
-    artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.set_presence(status="Lunch")
 
-    assert artifact.presence.status == {None: "Lunch"}
+    assert artifact.presence.current_presence.status == "Lunch"
 
 
-def test_set_presence_status_dict():
+async def test_set_presence_priority():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
-
-    artifact.presence.set_presence(status={"en": "Lunch"})
-
-    assert artifact.presence.status == {"en": "Lunch"}
-
-
-def test_set_presence_priority():
-    artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.set_presence(priority=5)
 
-    assert artifact.presence.priority == 5
+    assert artifact.presence.current_presence.priority == 5
 
 
-def test_set_presence():
+async def test_set_presence():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.set_presence(
-        state=PresenceState(True, PresenceShow.PLAIN), status="Lunch", priority=2
+        show=PresenceShow.NONE, status="Lunch", priority=2
     )
 
-    assert artifact.presence.is_available()
-    assert artifact.presence.state.show == PresenceShow.PLAIN
-    assert artifact.presence.status == {None: "Lunch"}
-    assert artifact.presence.priority == 2
+    assert artifact.presence.current_presence.is_available()
+    assert artifact.presence.current_presence.show == PresenceShow.NONE
+    assert artifact.presence.current_presence.status == "Lunch"
+    assert artifact.presence.current_presence.priority == 2
 
 
-def test_get_contacts_empty():
+async def test_get_contacts_empty():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     assert artifact.presence.get_contacts() == {}
 
 
-def test_get_contacts(jid):
+async def test_get_contacts(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My Friend"
-
-    artifact.presence.roster._update_entry(item)
+    artifact.presence.handle_roster_update(iq)
 
     contacts = artifact.presence.get_contacts()
 
-    bare_jid = jid.bare()
+    bare_jid = jid.bare
     assert bare_jid in contacts
-    assert type(contacts[bare_jid]) == dict
-    assert contacts[bare_jid]["approved"]
-    assert contacts[bare_jid]["name"] == "My Friend"
-    assert contacts[bare_jid]["subscription"] == "none"
-    assert "ask" not in contacts[bare_jid]
-    assert "groups" not in contacts[bare_jid]
+    assert type(contacts[bare_jid]) is spade.presence.Contact
+    assert contacts[bare_jid].name == "My Friend"
+    assert contacts[bare_jid].subscription == "both"
+    assert contacts[bare_jid].ask is 'none'
+    assert contacts[bare_jid].groups == []
 
 
-def test_get_contacts_with_presence(jid):
+async def test_get_contacts_with_presence(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My Available Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My Available Friend"
+    artifact.presence.handle_roster_update(iq)
 
-    artifact.presence.roster._update_entry(item)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type('available')
 
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
 
     contacts = artifact.presence.get_contacts()
 
-    bare_jid = jid.bare()
+    bare_jid = jid.bare
     assert bare_jid in contacts
-    assert contacts[bare_jid]["name"] == "My Available Friend"
+    assert contacts[bare_jid].name == "My Available Friend"
 
-    assert contacts[bare_jid]["presence"].type_ == PresenceType.AVAILABLE
+    assert contacts[bare_jid].current_presence.type == PresenceType.AVAILABLE
 
 
-def test_get_contacts_with_presence_on_and_off(jid):
+async def test_get_contacts_with_presence_on_and_off(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My Friend"
+    artifact.presence.handle_roster_update(iq)
 
-    artifact.presence.roster._update_entry(item)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type('available')
 
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
-    stanza = Presence(from_=jid, type_=PresenceType.UNAVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
+    presence.set_type('unavailable')
+    artifact.presence.handle_presence(presence)
 
     contacts = artifact.presence.get_contacts()
 
-    bare_jid = jid.bare()
+    bare_jid = jid.bare
     assert bare_jid in contacts
-    assert contacts[bare_jid]["name"] == "My Friend"
+    assert contacts[bare_jid].name == "My Friend"
 
-    assert contacts[bare_jid]["presence"].type_ == PresenceType.UNAVAILABLE
+    assert contacts[bare_jid].current_presence.type == PresenceType.UNAVAILABLE
 
 
-def test_get_contacts_with_presence_unavailable(jid):
+async def test_get_contacts_with_presence_unavailable(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My UnAvailable Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My UnAvailable Friend"
+    artifact.presence.handle_roster_update(iq)
 
-    artifact.presence.roster._update_entry(item)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type('unavailable')
 
-    stanza = Presence(from_=jid, type_=PresenceType.UNAVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
 
     contacts = artifact.presence.get_contacts()
 
-    bare_jid = jid.bare()
+    bare_jid = jid.bare
     assert bare_jid in contacts
-    assert contacts[bare_jid]["name"] == "My UnAvailable Friend"
+    assert contacts[bare_jid].name == "My UnAvailable Friend"
+    assert contacts[bare_jid].current_presence.type == PresenceType.UNAVAILABLE
 
-    assert "presence" not in contacts[bare_jid]
 
-
-def test_get_contact(jid):
+async def test_get_contact(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My Friend"
-
-    artifact.presence.roster._update_entry(item)
+    artifact.presence.handle_roster_update(iq)
 
     contact = artifact.presence.get_contact(jid)
 
-    assert type(contact) == dict
-    assert contact["approved"]
-    assert contact["name"] == "My Friend"
-    assert contact["subscription"] == "none"
-    assert "ask" not in contact
-    assert "groups" not in contact
+    assert type(contact) is spade.presence.Contact
+    assert contact.name == "My Friend"
+    assert contact.subscription == "both"
+    assert contact.is_subscribed()
+    assert contact.ask is 'none'
+    assert contact.groups == []
 
 
-def test_get_invalid_jid_contact():
+async def test_get_invalid_jid_contact():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     with pytest.raises(ContactNotFound):
-        artifact.presence.get_contact(JID.fromstr("invalid@contact"))
+        artifact.presence.get_contact(JID("invalid@contact"))
 
 
-def test_get_invalid_str_contact():
+async def test_get_invalid_str_contact():
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
-
-    with pytest.raises(AttributeError):
+    with pytest.raises(ContactNotFound):
         artifact.presence.get_contact("invalid@contact")
 
 
-def test_subscribe(jid):
+async def test_subscribe(jid):
     peer_jid = str(jid)
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.client = MagicMock()
 
-    artifact.client.enqueue = Mock()
     artifact.presence.subscribe(peer_jid)
 
-    assert artifact.client.enqueue.mock_calls
-    arg = artifact.client.enqueue.call_args[0][0]
+    artifact.client.send_presence.assert_called_with(pto=peer_jid, ptype="subscribe")
+    assert "friend@localhost/home" in artifact.presence.contacts
+    assert artifact.presence.contacts["friend@localhost/home"].subscription == "to"
+    assert artifact.presence.contacts["friend@localhost/home"].ask == "subscribe"
+    assert artifact.presence.contacts["friend@localhost/home"].name == peer_jid
 
-    assert arg.to == jid.bare()
-    assert arg.type_ == PresenceType.SUBSCRIBE
 
-
-def test_unsubscribe(jid):
+async def test_unsubscribe(jid):
     peer_jid = str(jid)
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.client = MagicMock()
 
-    artifact.client.enqueue = Mock()
+    artifact.presence.contacts[peer_jid] = Contact(
+        jid=JID(peer_jid), name=peer_jid, subscription="both", ask="", groups=[]
+    )
+
     artifact.presence.unsubscribe(peer_jid)
 
-    assert artifact.client.enqueue.mock_calls
-    arg = artifact.client.enqueue.call_args[0][0]
+    artifact.client.send_presence.assert_called_with(pto=peer_jid, ptype="unsubscribe")
+    assert "friend@localhost/home" in artifact.presence.contacts
+    assert artifact.presence.contacts["friend@localhost/home"].subscription == "from"
+    assert artifact.presence.contacts["friend@localhost/home"].ask == ""
+    assert artifact.presence.contacts["friend@localhost/home"].name == peer_jid
 
-    assert arg.to == jid.bare()
-    assert arg.type_ == PresenceType.UNSUBSCRIBE
 
-
-def test_approve(jid):
+async def test_approve(jid):
     peer_jid = str(jid)
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.client = MagicMock()
 
-    artifact.client.enqueue = Mock()
-    artifact.presence.approve(peer_jid)
+    artifact.presence.contacts[peer_jid] = Contact(
+        jid=JID(peer_jid), name=peer_jid, subscription="none", ask="", groups=[]
+    )
 
-    assert artifact.client.enqueue.mock_calls
-    arg = artifact.client.enqueue.call_args[0][0]
+    artifact.presence.approve_subscription(peer_jid)
 
-    assert arg.to == jid.bare()
-    assert arg.type_ == PresenceType.SUBSCRIBED
+    artifact.client.send_presence.assert_called_with(pto=peer_jid, ptype="subscribed")
+    assert "friend@localhost/home" in artifact.presence.contacts
+    assert artifact.presence.contacts["friend@localhost/home"].subscription == "from"
+    assert artifact.presence.contacts["friend@localhost/home"].ask == ""
+    assert artifact.presence.contacts["friend@localhost/home"].name == peer_jid
 
 
-def test_on_available(jid):
+async def test_on_available(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type('available')
 
     artifact.presence.on_available = Mock()
 
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
 
-    jid_arg = artifact.presence.on_available.call_args[0][0]
-    stanza_arg = artifact.presence.on_available.call_args[0][1]
+    jid_arg, presence_arg, last_pres_arg = artifact.presence.on_available.call_args[0]
 
     assert jid_arg == str(jid)
-    assert stanza_arg.type_ == PresenceType.AVAILABLE
+    assert presence_arg.type == PresenceType.AVAILABLE
 
 
-def test_on_unavailable(jid):
+async def test_on_unavailable(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type('unavailable')
 
     artifact.presence.on_unavailable = Mock()
-    artifact.presence.presenceclient._presences[jid.bare()] = {"home": None}
 
-    stanza = Presence(from_=jid, type_=PresenceType.UNAVAILABLE)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
 
-    jid_arg = artifact.presence.on_unavailable.call_args[0][0]
-    stanza_arg = artifact.presence.on_unavailable.call_args[0][1]
+    jid_arg, presence_arg, last_pres_arg = artifact.presence.on_unavailable.call_args[0]
 
     assert jid_arg == str(jid)
-    assert stanza_arg.type_ == PresenceType.UNAVAILABLE
+    assert presence_arg.type == PresenceType.UNAVAILABLE
 
 
-def test_on_subscribe(jid):
+async def test_on_subscribe(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.SUBSCRIBE.value)
 
     artifact.presence.on_subscribe = Mock()
 
-    stanza = Presence(from_=jid, type_=PresenceType.SUBSCRIBE)
-    artifact.presence.roster.handle_subscribe(stanza)
+    artifact.presence.handle_subscription(presence)
 
     jid_arg = artifact.presence.on_subscribe.call_args[0][0]
 
-    assert jid_arg == str(jid)
+    assert jid_arg == jid.bare
 
 
-def test_on_subscribe_approve_all(jid):
+async def test_on_subscribe_approve_all(jid):
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.approve_all = True
-    artifact.client.enqueue = Mock()
+    artifact.client = MagicMock()
 
-    stanza = Presence(from_=jid, type_=PresenceType.SUBSCRIBE)
-    artifact.presence.roster.handle_subscribe(stanza)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.SUBSCRIBE.value)
 
-    assert artifact.client.enqueue.mock_calls
-    arg = artifact.client.enqueue.call_args[0][0]
+    artifact.presence.handle_subscription(presence)
 
-    assert arg.to == jid.bare()
-    assert arg.type_ == PresenceType.SUBSCRIBED
+    assert artifact.client.send_presence.called
+    artifact.client.send_presence.assert_called_with(pto=jid.bare, ptype=PresenceType.SUBSCRIBED.value)
 
 
-def test_on_subscribed(jid):
+async def test_on_subscribed(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.SUBSCRIBED.value)
 
-    artifact.presence.on_subscribed = Mock()
+    artifact.presence.contacts[jid.bare] = Contact(
+        jid=jid.bare, name=jid.bare, subscription="none", ask="subscribe", groups=[]
+    )
 
-    stanza = Presence(from_=jid, type_=PresenceType.SUBSCRIBED)
-    artifact.presence.roster.handle_subscribed(stanza)
+    artifact.presence.handle_subscription(presence)
 
-    jid_arg = artifact.presence.on_subscribed.call_args[0][0]
+    assert len(artifact.presence.contacts) == 1
+    assert jid.bare in artifact.presence.contacts
+    stored_contact = artifact.presence.contacts[jid.bare]
+    assert stored_contact.jid == jid.bare
+    assert stored_contact.name == jid.bare
+    assert stored_contact.subscription == "to"
+    assert stored_contact.ask == ""
+    assert stored_contact.groups == []
 
-    assert jid_arg == str(jid)
 
-
-def test_on_unsubscribe(jid):
+async def test_on_unsubscribe(jid):
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     artifact.presence.on_unsubscribe = Mock()
 
-    stanza = Presence(from_=jid, type_=PresenceType.UNSUBSCRIBE)
-    artifact.presence.roster.handle_unsubscribe(stanza)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.UNSUBSCRIBE.value)
+
+    artifact.presence.handle_subscription(presence)
 
     jid_arg = artifact.presence.on_unsubscribe.call_args[0][0]
 
-    assert jid_arg == str(jid)
+    assert jid_arg == jid.bare
 
 
-def test_on_unsubscribe_approve_all(jid):
+async def test_on_unsubscribed(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.UNSUBSCRIBED.value)
 
-    artifact.presence.approve_all = True
-    artifact.client.enqueue = Mock()
+    artifact.presence.contacts[jid.bare] = Contact(
+        jid=jid.bare, name=jid.bare, subscription="both", ask="none", groups=[]
+    )
 
-    stanza = Presence(from_=jid, type_=PresenceType.UNSUBSCRIBE)
-    artifact.presence.roster.handle_unsubscribe(stanza)
+    artifact.presence.handle_subscription(presence)
 
-    assert artifact.client.enqueue.mock_calls
-    arg = artifact.client.enqueue.call_args[0][0]
+    assert len(artifact.presence.contacts) == 1
+    assert jid.bare in artifact.presence.contacts
+    stored_contact = artifact.presence.contacts[jid.bare]
+    assert stored_contact.jid == jid.bare
+    assert stored_contact.name == jid.bare
+    assert stored_contact.subscription == "to"
+    assert stored_contact.ask == ""
+    assert stored_contact.groups == []
 
-    assert arg.to == jid.bare()
-    assert arg.type_ == PresenceType.UNSUBSCRIBED
 
-
-def test_on_unsubscribed(jid):
+async def test_on_changed(jid):
     artifact = MockedConnectedArtifactFactory()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
-    future = artifact.start(auto_register=False)
-    future.result()
+    iq = Iq()
+    roster = Roster()
+    roster.set_items({
+        jid.bare: {
+            "name": "My Friend",
+            "subscription": "both"
+        }
+    })
+    iq.set_payload(roster)
 
-    artifact.presence.on_unsubscribed = Mock()
+    artifact.presence.handle_roster_update(iq)
 
-    stanza = Presence(from_=jid, type_=PresenceType.UNSUBSCRIBED)
-    artifact.presence.roster.handle_unsubscribed(stanza)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.AVAILABLE.value)
+    presence.set_show(PresenceShow.CHAT.value)
 
-    jid_arg = artifact.presence.on_unsubscribed.call_args[0][0]
-
-    assert jid_arg == str(jid)
-
-
-def test_on_changed(jid):
-    artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
-
-    item = XSOItem(jid=jid)
-    item.approved = True
-    item.name = "My Friend"
-
-    artifact.presence.roster._update_entry(item)
-
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE, show=PresenceShow.CHAT)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    artifact.presence.handle_presence(presence)
 
     contact = artifact.presence.get_contact(jid)
-    assert contact["name"] == "My Friend"
-    assert contact["presence"].show == PresenceShow.CHAT
+    assert contact.name == "My Friend"
+    assert contact.current_presence.show == PresenceShow.CHAT
 
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE, show=PresenceShow.AWAY)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    presence.set_show(PresenceShow.AWAY.value)
+
+    artifact.presence.handle_presence(presence)
 
     contact = artifact.presence.get_contact(jid)
 
-    assert contact["name"] == "My Friend"
-    assert contact["presence"].show == PresenceShow.AWAY
+    assert contact.name == "My Friend"
+    assert contact.current_presence.show == PresenceShow.AWAY
+    assert contact.last_presence.show == PresenceShow.CHAT
 
 
-def test_ignore_self_presence():
+async def test_ignore_self_presence():
     artifact = MockedConnectedArtifactFactory()
-
-    future = artifact.start(auto_register=False)
-    future.result()
+    artifact.loop = asyncio.get_event_loop()
+    await artifact.start(auto_register=False)
 
     jid = artifact.jid
 
-    stanza = Presence(from_=jid, type_=PresenceType.AVAILABLE, show=PresenceShow.CHAT)
-    artifact.presence.presenceclient.handle_presence(stanza)
+    presence = Presence()
+    presence['from'] = jid
+    presence.set_type(PresenceType.AVAILABLE.value)
+    presence.set_show(PresenceShow.CHAT.value)
+
+    artifact.presence.handle_presence(presence)
 
     with pytest.raises(ContactNotFound):
         artifact.presence.get_contact(jid)

--- a/tests/test_sqlreader.py
+++ b/tests/test_sqlreader.py
@@ -1,13 +1,19 @@
-import asynctest
-import unittest.mock as mock
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 from spade_artifact.common.readers.sqlreader import DatabaseQueryArtifact
 
-class TestDatabaseQueryArtifact(asynctest.TestCase):
 
-    async def setUp(self):
-        self.connection_params = {'host': 'localhost', 'user': 'test', 'password': 'test', 'database': 'testdb'}
+class TestDatabaseQueryArtifact(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.connection_params = {
+            'host': 'localhost',
+            'user': 'test',
+            'password': 'test',
+            'database': 'testdb'
+        }
         self.query = "SELECT * FROM test_table"
-        self.mock_db_connection = mock.MagicMock()
+        self.mock_db_connection = MagicMock()
 
     def test_connection_parameters_validation_postgresql(self):
         with self.assertRaises(ValueError):
@@ -24,18 +30,18 @@ class TestDatabaseQueryArtifact(asynctest.TestCase):
             artifact = DatabaseQueryArtifact("jid@test.com", "password", "sqlite", {}, self.query)
             artifact.validate_connection_params()
 
-    @asynctest.mock.patch('sqlite3.connect', return_value=mock.MagicMock())
+    @patch('sqlite3.connect', return_value=MagicMock())
     async def test_query_execution_sqlite(self, mocked_connect):
         artifact = DatabaseQueryArtifact("jid@test.com", "password", "sqlite",
                                          {'database': 'test.db'}, self.query)
         artifact.conn = mocked_connect()
-        artifact.publish = asynctest.CoroutineMock()
-        artifact.presence = asynctest.MagicMock()
-        artifact.presence.set_available = asynctest.CoroutineMock()
+        artifact.publish = AsyncMock()
+        artifact.presence = MagicMock()
+        artifact.presence.set_available = AsyncMock()
         artifact.cur = artifact.conn.cursor.return_value
 
         artifact.cur.fetchall.return_value = [("data1",), ("data2",)]
-        data_processor = asynctest.CoroutineMock(return_value=[{"processed": "data"}])
+        data_processor = AsyncMock(return_value=[{"processed": "data"}])
         artifact.data_processor = data_processor
 
         await artifact.run()
@@ -44,4 +50,3 @@ class TestDatabaseQueryArtifact(asynctest.TestCase):
         artifact.cur.execute.assert_called_with(self.query)
         artifact.cur.fetchall.assert_called_once()
         self.assertEqual(data_processor.call_args[0][0], [("data1",), ("data2",)])
-


### PR DESCRIPTION
- Drop aioxmpp dependency in favor of slixmpp, to keep compatibility with new SPADE versions (with slixmpp aswell)
- Drop use of asynctest in favor of unittest. Fix test using old Future statement. Convert most of test on async test
- Drop redundant dependencies, that are already present in SPADE (pyjabber/loguru/slixmpp,...)
- Update version in some dependencies