### PR TITLE
fix: integration with 4.1.3-4

### DIFF
--- a/spade_artifact/agent.py
+++ b/spade_artifact/agent.py
@@ -1,6 +1,7 @@
 from loguru import logger
 from spade_pubsub import PubSubMixin
 from slixmpp.stanza.message import Message as SlixmppMessage
+from xml.etree.ElementTree import tostring as _et_tostring
 
 
 class ArtifactMixin(PubSubMixin):
@@ -29,7 +30,10 @@ class ArtifactComponent:
         node = msg["pubsub_event"]["items"]["node"]
         if node in self.focus_callbacks:
             item = msg["pubsub_event"]["items"]["item"]["payload"]
-            jid = msg["pubsub_event"]["items"]["item"]["publisher"]
+            jid = msg["pubsub_event"]["items"]["item"].get("publisher")
+            # Fallback: if publisher is missing/empty use the node identifier
+            if not jid:
+                jid = node
             self.focus_callbacks[node](jid, item.text)
 
     async def focus(self, artifact_jid, callback):
@@ -37,6 +41,8 @@ class ArtifactComponent:
         self.focus_callbacks[artifact_jid] = callback
 
     async def ignore(self, artifact_jid):
-        await self.agent.pubsub.unsubscribe(self.agent.pubsub_server, str(artifact_jid))
+        data = await self.agent.pubsub.get_node_subscriptions(self.agent.pubsub_server, str(artifact_jid))
+        subid = data[0] if data else None
+        await self.agent.pubsub.unsubscribe(self.agent.pubsub_server, str(artifact_jid), subid=subid)
         if artifact_jid in self.focus_callbacks:
             del self.focus_callbacks[artifact_jid]

--- a/spade_artifact/artifact.py
+++ b/spade_artifact/artifact.py
@@ -132,14 +132,17 @@ class Artifact(PubSubMixin, AbstractArtifact):
             await self.pubsub.create(self.pubsub_server, f"{self._node}")
         except IqError as e:
             if e.condition == _DEFAULT_ERROR_TYPES["conflict"]:
-                logger.info(f"Node {self._node} already registered")
+                # Node already exists: treat as non-fatal and continue.
+                logger.info(f"Node {self._node} already registered; reusing it")
             elif e.condition == _DEFAULT_ERROR_TYPES["forbidden"]:
+                # Forbidden is fatal: keep existing behavior and raise.
                 logger.error(
                     f"Artifact {self._node} is not allowed to publish properties."
                 )
+                raise e
             else:
                 logger.error(f"Error creating node: {e.format()}")
-            raise e
+                raise e
 
         await self.setup()
         self._alive.set()
@@ -238,7 +241,6 @@ class Artifact(PubSubMixin, AbstractArtifact):
 
         if self.is_alive():
             await self.client.disconnect()
-            logger.info("Client disconnected.")
 
         self._alive.clear()
 


### PR DESCRIPTION
This PR addresses artifact integration issues for the new version.

Changes in agent.py:
- Fixes empty artifact name in the message received by the agent callback.
- Includes subid in PubSub unsubscribe handling.

Changes in artifact.py:
- Allows duplicated PubSub node creation when the owner is the same, without raising an exception.